### PR TITLE
Make timecracker.py Compatible with Python 3

### DIFF
--- a/extra-scripts/timecrack.py
+++ b/extra-scripts/timecrack.py
@@ -57,7 +57,7 @@ passwords that are popular in an organisation.
 """)
 
   argparser.add_argument('hashes', type=FileType('r'), help='Output of timeroast.py')
-  argparser.add_argument('dictionary', type=FileType('r'), help='Line-delimited password dictionary')
+  argparser.add_argument('dictionary', type=FileType('r', encoding='latin-1'), help='Line-delimited password dictionary')
   args = argparser.parse_args()
 
   crackcount = 0


### PR DESCRIPTION
Python 3 handles str as a Unicode string, which introduces differences in how the I/O layer decodes bytes—commonly using UTF-8 by default. In contrast, Python 2 treats str as a raw byte string. This discrepancy causes compatibility issues when reading dictionary files containing non-UTF-8 characters.

This pull request applies minimal changes to ensure timecracker.py runs correctly under Python 3, addressing the compatibility issue raised in [Issue #1](https://github.com/SecuraBV/Timeroast/issues/1).